### PR TITLE
Added const to char* argument

### DIFF
--- a/00-ESP8266_LIBRARY/esp8266.c
+++ b/00-ESP8266_LIBRARY/esp8266.c
@@ -2305,7 +2305,7 @@ ESP8266_Result_t ESP8266_SetAutoConnect(ESP8266_t* ESP8266, ESP8266_AutoConnect_
 /******************************************/
 /*               TCP CLIENT               */
 /******************************************/
-ESP8266_Result_t ESP8266_StartClientConnectionTCP(ESP8266_t* ESP8266, const char* name, char* location, uint16_t port, void* user_parameters) {
+ESP8266_Result_t ESP8266_StartClientConnectionTCP(ESP8266_t* ESP8266, const char* name, const char* location, uint16_t port, void* user_parameters) {
     return StartClientConnection(ESP8266, NULL, ESP8266_ConnectionType_TCP, "TCP", name, location, port, 0, user_parameters, 0);
 }
 

--- a/00-ESP8266_LIBRARY/esp8266.h
+++ b/00-ESP8266_LIBRARY/esp8266.h
@@ -795,7 +795,7 @@ ESP8266_Result_t ESP8266_Ping(ESP8266_t* ESP8266, const char* addr);
  * \param  *user_parameters: Pointer to custom user parameters (if needed) which will later be passed to callback functions for client connection
  * \retval Member of \ref ESP8266_Result_t enumeration
  */
-ESP8266_Result_t ESP8266_StartClientConnectionTCP(ESP8266_t* ESP8266, const char* name, char* location, uint16_t port, void* user_parameters);
+ESP8266_Result_t ESP8266_StartClientConnectionTCP(ESP8266_t* ESP8266, const char* name, const char* location, uint16_t port, void* user_parameters);
 
 /**
  * \brief  Starts new TCP connection as ESP client and connects to given address and port and waits for response


### PR DESCRIPTION
In ESP8266_StartClientConnectionTCP, add const to char* location argument. Avoids some unnecessary casts using the library.