### PR TITLE
Reset esp working structure in init

### DIFF
--- a/00-ESP8266_LIBRARY/esp8266.c
+++ b/00-ESP8266_LIBRARY/esp8266.c
@@ -1406,7 +1406,10 @@ ESP8266_Result_t SendMACCommand(ESP8266_t* ESP8266, uint8_t* addr, const char* c
 /******************************************/
 ESP8266_Result_t ESP8266_Init(ESP8266_t* ESP8266, uint32_t baudrate) {
     uint8_t i;
-    
+
+    // Reset the working structure
+    memset(ESP8266, 0, sizeof(*ESP8266));
+
     ESP8266->Timeout = 0;                                   /* Save settings */    
     if (BUFFER_Init(&TMP_Buffer, ESP8266_TMPBUFFER_SIZE + 1, TMPBuffer)) {  /* Init temporary buffer */
         ESP8266_RETURNWITHSTATUS(ESP8266, ESP_NOHEAP);


### PR DESCRIPTION
Examples do not show that structure needs to
be zeroed, but init does not always work unless
some of the variables are reset to 0. Zero at init
is a solution to this problem.
