### PR TITLE
Add function to set WIFI mode.

### DIFF
--- a/00-ESP8266_LIBRARY/esp8266.c
+++ b/00-ESP8266_LIBRARY/esp8266.c
@@ -946,7 +946,9 @@ PT_THREAD(PT_Thread_WIFI(struct pt* pt, evol ESP_t* ESP)) {
     if (ESP->ActiveCmd == CMD_WIFI_CWMODE) {                /* Set device mode */
         NumberToString(str, Pointers.UI);                   /* Convert mode to string */
         __RST_EVENTS_RESP(ESP);                             /* Reset all events */
-        UART_SEND_STR(FROMMEM("AT+CWMODE="));               /* Send data */
+        UART_SEND_STR(FROMMEM("AT+CWMODE_"));               /* Send data */
+        UART_SEND_STR(FROMMEM(Pointers.CPtr1));
+        UART_SEND_STR(FROMMEM("="));
         UART_SEND_STR(FROMMEM(str));
         UART_SEND_STR(_CRLF);
         StartCommand(ESP, CMD_WIFI_CWMODE, NULL);           /* Start command */
@@ -1763,6 +1765,7 @@ ESP_Result_t ESP_Init(evol ESP_t* ESP, uint32_t baudrate, ESP_EventCallback_t ca
     }
 #endif /* ESP_USE_CTS */
     while (i) {
+        Pointers.CPtr1 = FROMMEM("CUR");
         Pointers.UI = 3;
         __ACTIVE_CMD(ESP, CMD_WIFI_CWMODE);                 /* Set device mode */
         ESP_WaitReady(ESP, ESP->ActiveCmdTimeout);
@@ -2127,6 +2130,16 @@ ESP_Result_t ESP_GetSoftwareInfo(evol ESP_t* ESP, char* atv, char* sdkv, char* c
     Pointers.CPtr3 = (const void *)cmpt;
     
     __RETURN_BLOCKING(ESP, blocking, 180000);               /* Return with blocking support */
+}
+
+ESP_Result_t ESP_SetMode(evol ESP_t* ESP, ESP_Mode_t mode, uint32_t def, uint32_t blocking) {
+    __CHECK_BUSY(ESP);                                      /* Check busy status */
+    __ACTIVE_CMD(ESP, CMD_WIFI_CWMODE);                     /* Set active command */
+
+    Pointers.CPtr1 = def ? FROMMEM("DEF") : FROMMEM("CUR");
+    Pointers.UI = (uint8_t)mode;
+
+    __RETURN_BLOCKING(ESP, blocking, 1000);                 /* Return with blocking support */
 }
 
 /******************************************************************************/

--- a/00-ESP8266_LIBRARY/esp8266.h
+++ b/00-ESP8266_LIBRARY/esp8266.h
@@ -939,6 +939,16 @@ ESP_Result_t ESP_FirmwareUpdate(evol ESP_t* ESP, uint32_t blocking);
 ESP_Result_t ESP_GetSoftwareInfo(evol ESP_t* ESP, char* atv, char* sdkv, char* cmpt, uint32_t blocking);
 
 /**
+ * \brief         Set WIFI mode for ESP8266 device
+ * \param[in,out] *ESP: Pointer to working \ref ESP_t structure
+ * \param[in]     mode: WIFI mode \ref ESP_Mode_t
+ * \param[in]     def: Status whether this mode should be stored to ESP flash or not
+ * \param[in]     blocking: Status whether this function should be blocking to check for response
+ * \retval        Member of \ref ESP_Result_t enumeration
+ */
+ESP_Result_t ESP_SetMode(evol ESP_t* ESP, ESP_Mode_t mode, uint32_t def, uint32_t blocking);
+
+/**
  * \}
  */
  

--- a/00-ESP8266_LIBRARY/esp8266.h
+++ b/00-ESP8266_LIBRARY/esp8266.h
@@ -939,9 +939,9 @@ ESP_Result_t ESP_FirmwareUpdate(evol ESP_t* ESP, uint32_t blocking);
 ESP_Result_t ESP_GetSoftwareInfo(evol ESP_t* ESP, char* atv, char* sdkv, char* cmpt, uint32_t blocking);
 
 /**
- * \brief         Set WIFI mode for ESP8266 device
+ * \brief         Set WIFI mode for ESP8266 device, either STA, AP or both
  * \param[in,out] *ESP: Pointer to working \ref ESP_t structure
- * \param[in]     mode: WIFI mode \ref ESP_Mode_t
+ * \param[in]     mode: ESP8266 working mode. This parameter can be a value of \ref ESP_Mode_t enumeration
  * \param[in]     def: Status whether this mode should be stored to ESP flash or not
  * \param[in]     blocking: Status whether this function should be blocking to check for response
  * \retval        Member of \ref ESP_Result_t enumeration


### PR DESCRIPTION
In the earlier version (for example v1.2), the library had a function to set the Wifi mode (command CWMODE). The new library (>= v2.0) does not have this function.
I'm added this function in actual version.
